### PR TITLE
Don't cover up non-cache miss errors on GET

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -496,6 +496,7 @@ func (c *GenericCache) Get(key string, value interface{}) error {
 		if err != nil {
 			if err.Error() != persistence.ErrCacheMiss.Error() {
 				c.logError(fmt.Sprintf("GenericCache.Get: L%v/T%v error == %s", c.cLevel, c.cType, err.Error()))
+				return err
 			}
 			return persistence.ErrCacheMiss
 		}


### PR DESCRIPTION
Currently, the `GenericCache.Get` function returns `persistence.ErrCacheMiss` on any error making a `GET` on the underlying cache client. This means, as a client, I cannot tell whether my `GET` failed due to Redis being down (which I'll want to track with metrics/alerts) or just from cache miss.

This adds a return in the non-ErrCacheMiss case.